### PR TITLE
Added Persistent Subscription support

### DIFF
--- a/samples/openbank/api/main.py
+++ b/samples/openbank/api/main.py
@@ -12,6 +12,7 @@ from neuroglia.serialization.json import JsonSerializer
 
 
 database_name = "openbank"
+consumer_group = "openbank1"
 application_module = "samples.openbank.application"
 
 builder = WebApplicationBuilder()
@@ -20,7 +21,7 @@ Mapper.configure(builder, [application_module])
 Mediator.configure(builder, [application_module])
 CloudEventIngestor.configure(builder, ["samples.openbank.integration.models"]) #replace application_module with name of module(s) defining cloud events to handle
 CloudEventPublisher.configure(builder)
-ESEventStore.configure(builder, EventStoreOptions(database_name))
+ESEventStore.configure(builder, EventStoreOptions(database_name, consumer_group))
 DataAccessLayer.WriteModel.configure(builder, [ "samples.openbank.domain.models" ], lambda builder_, entity_type, key_type: EventSourcingRepository.configure(builder_, entity_type, key_type))
 DataAccessLayer.ReadModel.configure(builder, [ "samples.openbank.integration.models" ], lambda builder_, entity_type, key_type: MongoRepository.configure(builder_, entity_type, key_type, database_name))
 JsonSerializer.configure(builder)

--- a/src/neuroglia/data/infrastructure/event_sourcing/abstractions.py
+++ b/src/neuroglia/data/infrastructure/event_sourcing/abstractions.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from typing import Any, List, Optional, Type
+from typing import Any, Callable, List, Optional, Type
 from neuroglia.data.abstractions import AggregateRoot
 
 
@@ -69,6 +69,24 @@ class EventRecord:
     ''' Gets a boolean indicating whether or not the recorded event is being replayed to its consumer/consumer group '''
     
 
+@dataclass
+class AckableEventRecord(EventRecord):
+    ''' Represents an ackable recorded event '''
+    
+    _ack_delegate : Callable = None
+
+    _nack_delegate : Callable= None
+
+    async def ack_async(self) -> None:
+        ''' Acks the event record '''
+        self._ack_delegate()
+        print("ACKED")
+
+    async def nack_async(self) -> None:
+        ''' Nacks the event record'''
+        self._nack_delegate()
+        
+
 class StreamReadDirection(Enum):
     ''' Enumerates all directions in which a event sourcing stream can be read '''
     FORWARDS=0,
@@ -82,6 +100,9 @@ class EventStoreOptions:
 
     database_name: str
     ''' Gets/sets the name of the database to use, if any '''
+    
+    consumer_group: str
+    ''' Gets/sets the name of the consumer group to use, if any '''
 
 class EventStore(ABC):
     ''' Defines the fundamentals of a service used to append and subscribe to sourced events '''

--- a/src/neuroglia/data/infrastructure/event_sourcing/read_model_reconciliator.py
+++ b/src/neuroglia/data/infrastructure/event_sourcing/read_model_reconciliator.py
@@ -2,7 +2,7 @@ import asyncio
 from dataclasses import dataclass
 import logging
 from rx.core.typing import Disposable
-from neuroglia.data.infrastructure.event_sourcing.abstractions import EventRecord, EventStore, EventStoreOptions
+from neuroglia.data.infrastructure.event_sourcing.abstractions import AckableEventRecord, EventRecord, EventStore, EventStoreOptions
 from neuroglia.dependency_injection.service_provider import ServiceProviderBase
 from neuroglia.hosting.abstractions import HostedService
 from neuroglia.mediation.mediator import Mediator
@@ -46,17 +46,20 @@ class ReadModelReconciliator(HostedService):
         self._subscription.dispose()
 
     async def subscribe_async(self):
-        observable = await self._event_store.observe_async(f'$ce-{self._event_store_options.database_name}')
+        observable = await self._event_store.observe_async(f'$ce-{self._event_store_options.database_name}', self._event_store_options.consumer_group)
         self._subscription = AsyncRx.subscribe(observable, lambda e: asyncio.run(self.on_event_record_stream_next_async(e)))
         
     async def on_event_record_stream_next_async(self, e: EventRecord):
         try:
             #todo: migrate event
             await self._mediator.publish_async(e.data)
-            #todo: ack
+            if isinstance(e, AckableEventRecord):
+                print("ACKING")
+                await e.ack_async()
         except Exception as ex:
             logging.error(f"An exception occured while publishing an event of type '{type(e.data).__name__}': {ex}")
-            pass #todo: nack
+            if isinstance(e, AckableEventRecord):
+                await e.nack_async()
     
     async def on_event_record_stream_error(self, ex: Exception):
         await self.subscribe_async()


### PR DESCRIPTION
- Adds the AckableEventRecord class, which allows consumers to ack/nack consumed events and to persist on ES its checkpoint

### Note to implementers

The EsdbClient does not yet allow to configure the persistent subscription's Min/Max Checkpoint Count, **requiring manual intervention on ES to make it work as expected on a per-event basis**.

See: https://github.com/pyeventsourcing/esdbclient/issues/21